### PR TITLE
comfirmable

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -16,15 +16,17 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # The path used after resending confirmation instructions.
   # def after_resending_confirmation_instructions_path_for(resource_name)
   #   super(resource_name)
   # end
 
-  # The path used after confirmation.
-  # def after_confirmation_path_for(resource_name, resource)
-  #   super(resource_name, resource)
-  # end
+  #The path used after confirmation.
+  def after_confirmation_path_for(resource_name, resource)
+    sign_in(resource)
+    root_path
+  end
+  
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -56,7 +56,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up for inactive accounts.
-  # def after_inactive_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_inactive_sign_up_path_for(resource)
+   root_path
+  end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -38,7 +38,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -51,10 +51,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
-
+  def after_sign_up_path_for(resource)
+    root_path
+  end
+  
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(resource)
    root_path

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,10 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable,
          :lockable, :omniauthable, omniauth_providers: [:google_oauth2]
-        # :confirmable,
+        
   
   before_save {email.downcase!}
   validates :username, presence: true, length: { maximum: 50}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,17 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :user_name => ENV['EMAIL_ADDRESS'],
+    :password => ENV['EMAIL_PASSWORD'],
+    :authentication => :plain,
+    :enable_starttls_auto => true
+  }
+
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,8 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
-
+  config.mailer_sender = ENV['EMAIL_ADDRESS']
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     :registrations => 'users/registrations',
     :sessions => 'users/sessions',
-    :omniauth_callbacks => 'users/omniauth_callbacks'
+    :omniauth_callbacks => 'users/omniauth_callbacks',
+    :confirmations => 'users/confirmations'
+
   }
   
   # devise :omniauthable: :omniauth_providers => [:google_oauth2]


### PR DESCRIPTION
有効化メールの送信、新規登録完了まで実装。
リダイレクト先をログイン後のroot_pathへ修正必要