### PR TITLE
webpacker performance

### DIFF
--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -9,6 +9,9 @@ environment.toWebpackConfig().merge({
     alias: {
       'vue': 'vue/dist/vue.esm.js'
     }
+  },
+  performance:{
+    hints: false
   }
 });
 


### PR DESCRIPTION
WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  application (1.63 MiB)
      js/application-8f3c97365ec1685295a4.js
  main (945 KiB)
      js/main-a0f014aaa0fdaef436be.js
  router (264 KiB)
      js/router-5636e87669b1eb601c6e.js


WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

上記エラーに対応